### PR TITLE
Fix: Allow spaces in markdown filenames

### DIFF
--- a/src/app/api/files/[filename]/route.ts
+++ b/src/app/api/files/[filename]/route.ts
@@ -39,10 +39,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     
     const decodedFilename = decodeURIComponent(filename);
     
-    // Validate decoded filename format
-    if (!/^[a-zA-Z0-9._-]+\.md$/.test(decodedFilename)) {
+    // Validate decoded filename format - allow spaces and common characters but prevent path traversal
+    if (!/^[a-zA-Z0-9._\s-]+\.md$/.test(decodedFilename) || decodedFilename.includes('..') || decodedFilename.includes('/') || decodedFilename.includes('\\')) {
       return NextResponse.json(
-        { success: false, error: 'Invalid filename format. Must be alphanumeric with .md extension' },
+        { success: false, error: 'Invalid filename format. Must end with .md and contain only letters, numbers, spaces, dots, underscores, and hyphens' },
         { status: 400 }
       );
     }
@@ -101,10 +101,10 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     
     const decodedFilename = decodeURIComponent(filename);
     
-    // Validate decoded filename format
-    if (!/^[a-zA-Z0-9._-]+\.md$/.test(decodedFilename)) {
+    // Validate decoded filename format - allow spaces and common characters but prevent path traversal
+    if (!/^[a-zA-Z0-9._\s-]+\.md$/.test(decodedFilename) || decodedFilename.includes('..') || decodedFilename.includes('/') || decodedFilename.includes('\\')) {
       return NextResponse.json(
-        { success: false, error: 'Invalid filename format. Must be alphanumeric with .md extension' },
+        { success: false, error: 'Invalid filename format. Must end with .md and contain only letters, numbers, spaces, dots, underscores, and hyphens' },
         { status: 400 }
       );
     }

--- a/src/app/api/files/create/route.ts
+++ b/src/app/api/files/create/route.ts
@@ -48,10 +48,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate filename format
-    if (!/^[a-zA-Z0-9._-]+\.md$/.test(filename)) {
+    // Validate filename format - allow spaces and common characters but prevent path traversal
+    if (!/^[a-zA-Z0-9._\s-]+\.md$/.test(filename) || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
       return NextResponse.json(
-        { success: false, error: 'Invalid filename format. Must be alphanumeric with .md extension' },
+        { success: false, error: 'Invalid filename format. Must end with .md and contain only letters, numbers, spaces, dots, underscores, and hyphens' },
         { status: 400 }
       );
     }


### PR DESCRIPTION
## Summary
Fixes overly restrictive filename validation that was rejecting filenames containing spaces.

## Problem
The API was returning "Invalid filename format" errors for filenames with spaces like:
- `my document.md`
- `meeting notes.md` 
- `project plan v2.md`

## Solution
- Updated regex pattern from `/^[a-zA-Z0-9._-]+\.md$/` to `/^[a-zA-Z0-9._\s-]+\.md$/`
- Added explicit path traversal prevention checks
- Improved error message to clearly state supported characters

## Security
Maintains security by explicitly preventing:
- Path traversal attacks (`..`, `/`, `\`)
- Invalid file extensions
- Empty or malformed filenames

## Files Changed
- `src/app/api/files/create/route.ts` - Create file validation
- `src/app/api/files/[filename]/route.ts` - File access validation

## Test Cases
✅ `document.md` - Works  
✅ `my document.md` - Now works  
✅ `meeting-notes_v2.md` - Works  
❌ `../secret.md` - Blocked (security)  
❌ `file.txt` - Blocked (wrong extension)

This fix resolves user experience issues while maintaining security standards.

🤖 Generated with [Claude Code](https://claude.ai/code)